### PR TITLE
Contact: remove form, align fallback styling, enforce dark theme

### DIFF
--- a/astro-website/public/_redirects
+++ b/astro-website/public/_redirects
@@ -25,4 +25,8 @@ http://www.coastlinesprayfoam.com/* https://coastlinesprayfoam.com/:splat 301!
 /contact.html /contact/ 301!
 /warranty.html /warranty/ 301!
 /blog-post.html /blog-post.html 301!
+# Back-compat: flat routes that exist as .html in the build
+/privacy-policy /privacy-policy.html 301!
+/terms-of-service /terms-of-service.html 301!
+/gallery /gallery.html 301!
 

--- a/astro-website/public/contact.html
+++ b/astro-website/public/contact.html
@@ -61,10 +61,6 @@ permalink: /contact/
   </script>
 </head>
 <body>
-<<<<<<< HEAD
-  <!-- Unified Navigation Container -->
-  <div id="unified-nav"></div>
-=======
   <!-- Navigation -->
   <nav class="navbar navbar-expand-lg fixed-top">
     <div class="container">
@@ -92,7 +88,6 @@ permalink: /contact/
       </div>
     </div>
   </nav>
->>>>>>> 69aa55a65de5f20b97778e5f1a39990c4a10fdf2
 
   <!-- Hero Section -->
   <section class="hero">
@@ -417,7 +412,7 @@ permalink: /contact/
 
   <!-- Custom JS -->
   <script>
-    // Contact form removed intentionally. Keep page interactive elements minimal.
+  <!-- Contact form removed intentionally. Keep page interactive elements minimal. -->
 
     // Navbar scroll effect
     window.addEventListener('scroll', function() {

--- a/astro-website/public/contact.html
+++ b/astro-website/public/contact.html
@@ -35,7 +35,9 @@ permalink: /contact/
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 
   <!-- Custom CSS -->
-  <link href="assets/css/style.css" rel="stylesheet">
+  <link href="/assets/css/style.css" rel="stylesheet">
+  <link href="/assets/css/navigation-mobile.css" rel="stylesheet">
+  <link href="/assets/css/critical.css" rel="stylesheet">
 
   <!-- Structured Data -->
   <script type="application/ld+json">
@@ -60,11 +62,11 @@ permalink: /contact/
   }
   </script>
 </head>
-<body>
-  <!-- Navigation -->
-  <nav class="navbar navbar-expand-lg fixed-top">
+<body data-theme="dark">
+  <!-- Navigation (match Layout markup/classes) -->
+  <nav class="navbar navbar-expand-lg navbar-dark fixed-top">
     <div class="container">
-      <a class="navbar-brand" href="index.html">
+      <a class="navbar-brand" href="/index.html">
         <strong>Coastline Spray Foam</strong>
       </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-label="Toggle navigation">
@@ -72,13 +74,13 @@ permalink: /contact/
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav ms-auto align-items-center">
-          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
-          <li class="nav-item"><a class="nav-link" href="services.html">Services</a></li>
-          <li class="nav-item"><a class="nav-link" href="service-areas.html">Areas</a></li>
-          <li class="nav-item"><a class="nav-link" href="gallery.html">Gallery</a></li>
-          <li class="nav-item"><a class="nav-link" href="blog.html">Blog</a></li>
-          <li class="nav-item"><a class="nav-link active" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="nav-link" href="/index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="/about.html">About</a></li>
+          <li class="nav-item"><a class="nav-link" href="/services.html">Services</a></li>
+          <li class="nav-item"><a class="nav-link" href="/service-areas.html">Areas</a></li>
+          <li class="nav-item"><a class="nav-link" href="/gallery.html">Gallery</a></li>
+          <li class="nav-item"><a class="nav-link" href="/blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link active" href="/contact.html">Contact</a></li>
           <li class="nav-item">
             <a class="nav-link phone-nav-link" href="tel:3216527465">
               📞 Call (321) 652-7465

--- a/astro-website/src/layouts/Layout.astro
+++ b/astro-website/src/layouts/Layout.astro
@@ -67,7 +67,7 @@ const { title, description = "Professional spray foam insulation services in Flo
   <link href="../../assets/css/style.css" rel="stylesheet">
   <link href="../../assets/css/navigation-mobile.css" rel="stylesheet">
 </head>
-<body>
+<body data-theme="dark">
   <!-- Skip Link for Accessibility -->
   <a href="#main-content" class="skip-link">Skip to main content</a>
 


### PR DESCRIPTION
Fixes: align public fallback contact page with Astro Layout styling, remove online quote form and replace with direct Call/Email CTAs, set data-theme=dark in Layout and fallback to preserve site dark theme.\n\nQA:\n- Built site locally and verified /contact.html in dist displays correctly with dark theme.\n- Local link-check reports generated to dist/link-check-http-report.csv and link-check-urls.csv for review.\n\nNotes:\n- Preserves legacy flat .html routes and adds/uses redirects in public/_redirects.\n- Recommended post-merge: monitor Cloudflare Pages build logs and run Lighthouse audits for /contact and /about.